### PR TITLE
feat: add Directory Addon

### DIFF
--- a/packages/client/src/client/addons/directory/DirectoryAddon.svelte
+++ b/packages/client/src/client/addons/directory/DirectoryAddon.svelte
@@ -1,0 +1,65 @@
+<script>
+  import Addon from '../Addon.svelte';
+  import FolderClosedIcon from ':virtual/vitebook/icons/sidebar-folder-closed?raw';
+  import {activeVariant, variants} from "../../stores/variants.js";
+
+  export let title = 'Directory';
+  export let icon = FolderClosedIcon;
+
+</script>
+
+<Addon {title} {icon}>
+  <div class="addon__directory">
+    {#each Object.values($variants) as item (item.id)}
+      <button
+        class:active={$activeVariant?.id === item.id}
+        on:click={()=>variants.setActive(item.id)}
+      >
+        {item.name}
+      </button>
+      {:else}
+      <button>
+        Nothing at all
+      </button>
+    {/each}
+  </div>
+</Addon>
+<style>
+  button {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: var(--vbk--sidebar-item-padding);
+    border: 0;
+    font-size: var(--vbk--sidebar-item-font-size);
+    margin-top: var(--vbk--sidebar-item-spacing);
+    font-weight: var(--vbk--sidebar-item-font-weight);
+    border-radius: var(--vbk--sidebar-item-border-radius);
+    color: var(--vbk--sidebar-item-color);
+    white-space: nowrap;
+    text-decoration: none;
+    background-color: var(--vbk--sidebar-item-bg-color);
+    text-align: left;
+    cursor: var(--vbk--sidebar-item-cursor, pointer);
+    line-height: var(--vbk--sidebar-item-line-height);
+  }
+
+  button.active {
+    color: var(--vbk--color-primary);
+    background-color: var(--vbk--sidebar-item-active-bg-color);
+  }
+
+  @media (min-width: 992px) {
+    button {
+      color: var(--vbk--nav-item-color);
+      background-color: var(--vbk--nav-item-bg-color);
+    }
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    button:hover {
+      color: var(--vbk--color-primary);
+      background-color: var(--vbk--sidebar-item-hover-bg-color);
+    }
+  }
+</style>

--- a/packages/client/src/client/addons/directory/index.ts
+++ b/packages/client/src/client/addons/directory/index.ts
@@ -1,0 +1,1 @@
+export { default as DirectoryAddon } from './DirectoryAddon.svelte';

--- a/packages/client/src/client/addons/index.ts
+++ b/packages/client/src/client/addons/index.ts
@@ -1,4 +1,5 @@
 export { default as Addon } from './Addon.svelte';
 export * from './addons';
 export * from './controls';
+export * from './directory';
 export * from './events';

--- a/packages/theme-default/src/client/components/Markdown/useNextAndPrevLinks.ts
+++ b/packages/theme-default/src/client/components/Markdown/useNextAndPrevLinks.ts
@@ -7,8 +7,8 @@ import { derived, Readable } from 'svelte/store';
 
 import type { SidebarLink } from '../../../shared';
 import { localizedThemeConfig } from '../../stores/localizedThemeConfig';
-import { flattenSidebarLinks } from '../sidebar/flattenSidebarLinks';
-import { sidebarItems } from '../sidebar/sidebarItems';
+import { flattenSidebarLinks } from '../Sidebar/flattenSidebarLinks';
+import { sidebarItems } from '../Sidebar/sidebarItems';
 
 const candidates = derived(sidebarItems, (items) =>
   isArray(items) ? flattenSidebarLinks(items) : [],

--- a/packages/theme-default/src/client/components/VariantsMenu.svelte
+++ b/packages/theme-default/src/client/components/VariantsMenu.svelte
@@ -16,6 +16,7 @@
   let open = false;
 
   let showingTooltipFor;
+  let client = {};
   let showingTooltipForTimer;
 
   $: variations = Object.values($variants);
@@ -110,7 +111,8 @@
           <button
             class="variants__menu-item__button"
             aria-describedby={`variant-tooltip-${variant.name}`}
-            on:pointerenter={() => {
+            on:pointerenter={(e) => {
+              client = { clientX: e.clientX, clientY: e.clientY };
               showingTooltipForTimer = setTimeout(() => {
                 showingTooltipFor = variant;
               }, 1000);
@@ -129,6 +131,7 @@
             <div
               id={`variant-tooltip-${variant.name}`}
               class="variants__menu-item__tooltip"
+              style={`left: ${client.clientX}px;top:${client.clientY}px`}
               role="tooltip"
               aria-hidden={showingTooltipFor !== variant ? 'true' : undefined}
             >
@@ -176,8 +179,7 @@
     position: absolute;
     top: 100%;
     right: 1rem;
-    padding: 0.8rem;
-    padding-bottom: 1rem;
+    padding: 0.8rem 0.8rem 1rem;
     margin: 0;
     opacity: 0;
     list-style: none;
@@ -186,9 +188,12 @@
     border-radius: 0.15rem;
     box-shadow: var(--vbk--elevation-medium);
     min-width: 10rem;
-    border: var(--vbk--menu-border);
+    /*border: var(--vbk--menu-border);*/
     background-color: var(--vbk--menu-bg-color);
     transition: var(--vbk--menu-transition);
+    overflow-y: auto;
+    overflow-x: hidden;
+    height: 80vh;
   }
 
   .variants__menu[aria-expanded='true'] {
@@ -221,10 +226,10 @@
     display: none;
     align-items: center;
     justify-content: center;
-    position: absolute;
+    position: fixed;
     padding: 0 0.5rem;
-    top: 0.5rem;
-    left: calc(100% + 0.25rem);
+    /*top: 0.5rem;*/
+    /*left: calc(100% + 0.25rem);*/
     min-width: 150px;
     max-width: 200px;
     font-size: 0.75rem;

--- a/packages/theme-default/src/client/layout/Layout.svelte
+++ b/packages/theme-default/src/client/layout/Layout.svelte
@@ -45,6 +45,8 @@
   let hasMounted = false;
 
   $: noNavbar = $localizedThemeConfig.navbar === false;
+  $: noVariantsMenu = $localizedThemeConfig.variantsMenuEnable === false;
+  $: noDirectory = $localizedThemeConfig.directoryEnable === false;
   $: isMarkdownPage = $currentPage?.type?.endsWith('md');
   $: hasVariants = Object.values($variants).length > 0;
   $: showPreviewTopBar = hasVariants;
@@ -137,7 +139,9 @@
     {#if showPreviewTopBar}
       <div class="preview__top-bar">
         <div style="flex-grow: 1;" />
-        <VariantsMenu />
+        {#if !noVariantsMenu}
+          <VariantsMenu />
+        {/if}
         <div style="flex-grow: 1;" />
       </div>
     {/if}
@@ -173,6 +177,11 @@
             <slot name="addons-end" />
           </svelte:fragment>
         </svelte:component>
+      {/await}
+    {/if}
+    {#if !isMarkdownPage && !noDirectory}
+      {#await import('@vitebook/client/addons/directory/DirectoryAddon.svelte') then Directory}
+        <svelte:component this={Directory.default} />
       {/await}
     {/if}
   </slot>

--- a/packages/theme-default/src/client/styles/global.css
+++ b/packages/theme-default/src/client/styles/global.css
@@ -344,3 +344,24 @@ blockquote.__vbk__ {
 blockquote.__vbk__ > p.__vbk__ {
   margin: 0;
 }
+
+/**-------------------------------------------------------------------------------------------
+ * scrollbar
+ *-------------------------------------------------------------------------------------------*/
+
+.__vbk__::-webkit-scrollbar {
+  width: 6px;
+}
+
+.__vbk__::-webkit-scrollbar-thumb {
+  background-color: rgba(69,90,100,.2);
+  border-radius: 10px;
+  transition: all .2s ease-in-out;
+}
+.dark .__vbk__::-webkit-scrollbar-thumb {
+  background-color: #525659;
+}
+
+.__vbk__::-webkit-scrollbar-track {
+  border-radius: 10px;
+}

--- a/packages/theme-default/src/shared/types/DefaultThemeConfig.ts
+++ b/packages/theme-default/src/shared/types/DefaultThemeConfig.ts
@@ -56,6 +56,14 @@ export type DefaultThemeLocaleData = {
    */
   sidebar?: SidebarConfig;
   /**
+   * VariantsMenu configuration.
+   */
+  variantsMenuEnable?: boolean;
+  /**
+   * DirectoryMenu configuration.
+   */
+  directoryEnable?: boolean;
+  /**
    * Markdown documentation configuration.
    */
   markdown?: MarkdownConfig;
@@ -375,6 +383,10 @@ export const defaultThemeLocaleOptions: Required<DefaultThemeLocaleData> = {
     backToMainMenuText: 'Back to main menu',
     toggleAriaLabel: 'Toggle sidebar menu',
   },
+
+  variantsMenuEnable: true,
+
+  directoryEnable: false,
 
   markdown: {
     toc: false,


### PR DESCRIPTION
I hope to have a clear directory plugin so that I can more easily go to the corresponding variant。

`packages/theme-default/src/client/components/Markdown/useNextAndPrevLinks.ts`This file may be changed due to case problems

