### PR TITLE
fix: windows path resolving of '.' in create-vitebook

### DIFF
--- a/packages/create/bin/create-vitebook.js
+++ b/packages/create/bin/create-vitebook.js
@@ -27,7 +27,10 @@ const argv = minimist(process.argv.slice(2), { string: ['_'] });
 async function main() {
   const projectDirName = argv._[0];
 
-  let targetDir = path.resolve(process.cwd(), projectDirName ?? '.');
+  let targetDir = process.cwd();
+  if (projectDirName) {
+    targetDir = path.resolve(targetDir, projectDirName);
+  }
   let template = argv.template;
   let theme = argv.theme;
   let features = argv.features?.split(',');

--- a/packages/create/src/FileDirectory.js
+++ b/packages/create/src/FileDirectory.js
@@ -36,9 +36,9 @@ export class FileDirectory {
     if (pathSegments && pathSegments.length > 0) {
       // Windows + Git Bash doesn't seem to play nicely with path.resolve
       // when any of the path segments are `.`
-      segments = pathSegments.filter(seg => seg !== '.');
+      segments = pathSegments.filter((seg) => seg !== '.');
     }
-    return path.resolve(this.path, segments);
+    return path.resolve(this.path, ...segments);
   }
 
   /**

--- a/packages/create/src/FileDirectory.js
+++ b/packages/create/src/FileDirectory.js
@@ -32,7 +32,13 @@ export class FileDirectory {
    * @param  {string[]} pathSegments
    */
   resolve(...pathSegments) {
-    return path.resolve(this.path, ...(pathSegments ?? []));
+    let segments = [];
+    if (pathSegments && pathSegments.length > 0) {
+      // Windows + Git Bash doesn't seem to play nicely with path.resolve
+      // when any of the path segments are `.`
+      segments = pathSegments.filter(seg => seg !== '.');
+    }
+    return path.resolve(this.path, segments);
   }
 
   /**


### PR DESCRIPTION
On windows, with Git Bash, I was receiving the overwrite prompt when running `yarn create vitebook` in my project root. Since the two checks that matter are `targetDir !== process.cwd()` and `fs.existsSync(targetDir)`, I believe the cause of the problem is a Windows and/or Git Bash path quirk.

I haven't tested this change, but since both of the checks need to be true, it means that `path.resolve()` isn't resolving `.` correctly. As a result, I'm confident that this change will let windows git bash users create their vitebook install in existing projects.

Although one concern I have is that the Theme code region in this file uses `.`. I don't know if that will be subject to the same issues, as I haven't looked at the ProjectBuilder object. I suspect that it _will_ be subject to the issue, so expect an additional commit