### PR TITLE
fix: add inBrowser check to ButtonLink

### DIFF
--- a/packages/theme-default/src/client/components/ButtonLink.svelte
+++ b/packages/theme-default/src/client/components/ButtonLink.svelte
@@ -1,5 +1,6 @@
 <script>
   import { withBaseUrl, useRouter } from '@vitebook/client';
+  import { inBrowser } from '@vitebook/core';
   import { darkMode } from '../stores/darkMode';
 
   export let href;
@@ -19,7 +20,7 @@
   class="button"
   class:dark={$darkMode}
   class:secondary={type === 'secondary'}
-  href={href === '_back' ? document.referrer : withBaseUrl(href)}
+  href={(href === '_back' && inBrowser) ? document.referrer : withBaseUrl(href)}
   on:click={onClick}
 >
   <slot />


### PR DESCRIPTION
When building a vitebook with a different baseUrl then `/` i kept getting an error that it tries to use `document` during the SSR build.